### PR TITLE
Print useful message when jsonEscapeCore throws an error.

### DIFF
--- a/utils/json_parsing.cc
+++ b/utils/json_parsing.cc
@@ -55,7 +55,7 @@ char * jsonEscapeCore(const std::string & str, char * p, char * end)
             case '\\':
             case '\"': *p++ = (c);  break;
             default:
-                throw Exception("invalid character in Json string");
+                throw Exception("Invalid character in JSON string: " + str);
             }
         }
     }


### PR DESCRIPTION
We had a couple of issues with UTF8-characters in JSON strings. These errors typically pop up once you receive live traffic and it's nearly impossible to debug if you don't know which are the offending strings...
