### PR TITLE
Fix problem with cmp_xchg when double

### DIFF
--- a/arch/cmp_xchg.h
+++ b/arch/cmp_xchg.h
@@ -19,6 +19,27 @@ namespace ML {
 template<unsigned Size>
 struct cmp_xchg_switch {
 
+    JML_ALWAYS_INLINE bool cmp_xchg(double & val, double & old,
+                                    const double & new_val)
+    {
+        auto _val = reinterpret_cast<volatile uint64_t *>(&val);
+        auto _old = reinterpret_cast<volatile uint64_t *>(&old);
+        auto _new_val = reinterpret_cast<const volatile uint64_t *>(&new_val);
+
+        return cmp_xchg(*_val, *_old, *_new_val);
+    }
+
+    JML_ALWAYS_INLINE bool cmp_xchg(volatile double & val,
+                                    volatile double & old,
+                                    volatile const double & new_val)
+    {
+        auto _val = reinterpret_cast<volatile uint64_t *>(&val);
+        auto _old = reinterpret_cast<volatile uint64_t *>(&old);
+        auto _new_val = reinterpret_cast<volatile const uint64_t *>(&new_val);
+
+        return cmp_xchg(*_val, *_old, *_new_val);
+    }
+
     template<class X>
     JML_ALWAYS_INLINE bool cmp_xchg(X & val, X & old, const X & new_val)
     {


### PR DESCRIPTION
- Gcc 4.8 is not correctly optimizing the code when using cmp_xchg
  assembly instruction together with double. This change will fix it by
  first converting the double to uint64_t and then calling the cmp_xchg
  instruction.
