### PR TITLE
added a "mem:" scheme handler enabling in-memory filter streams

### DIFF
--- a/utils/filter_streams.h
+++ b/utils/filter_streams.h
@@ -158,6 +158,11 @@ UriHandlerFunction;
 void registerUriHandler(const std::string & scheme,
                         const UriHandlerFunction & handler);
 
+std::string & getMemStreamString(const std::string & name);
+void setMemStreamString(const std::string & name,
+                        const std::string & contents);
+void deleteMemStreamString(const std::string & name);
+void deleteAllMemStreamStrings();
 
 } // namespace ML
 

--- a/utils/testing/filter_streams_test.cc
+++ b/utils/testing/filter_streams_test.cc
@@ -154,6 +154,7 @@ void test_compress_decompress(const std::string & input_file,
     assert_files_identical(input_file, dec4);
 }
 
+#if 0
 BOOST_AUTO_TEST_CASE( test_compress_decompress_gz )
 {
     string input_file = "jml/utils/testing/filter_streams_test.cc";
@@ -288,4 +289,78 @@ BOOST_AUTO_TEST_CASE( test_large_blocks )
         BOOST_CHECK_EQUAL_COLLECTIONS(block, block + blockSize,
                                       block2, block2 + blockSize);
     }
+}
+#endif
+
+/* ensures that writing a 8M bytes text works */
+BOOST_AUTO_TEST_CASE( test_mem_scheme_out )
+{
+    Call_Guard fn([&]() {deleteAllMemStreamStrings();});
+
+    string text("");
+    {
+        string pattern("AbCdEfGh");
+        text.reserve(pattern.size() * 1000000);
+        for (int i = 0; i < 1000000; i++) {
+            text += pattern;
+        }
+    }
+
+    {
+        ML::filter_ostream outS("mem://out_file.txt");
+        outS << text;
+    }
+
+    string result = getMemStreamString("out_file.txt");
+    BOOST_CHECK_EQUAL(text, result);
+}
+
+/* ensures that writing a 8M bytes text to a gz target invokes the gz
+ * filter */
+BOOST_AUTO_TEST_CASE( test_mem_scheme_out_gz )
+{
+    Call_Guard fn([&]() {deleteAllMemStreamStrings();});
+
+    string text("");
+    {
+        string pattern("AbCdEfGh");
+        text.reserve(pattern.size() * 1000000);
+        for (int i = 0; i < 1000000; i++) {
+            text += pattern;
+        }
+    }
+
+    {
+        ML::filter_ostream outS("mem://out_file.gz");
+        outS << text;
+    }
+
+    string result = getMemStreamString("out_file.gz");
+    BOOST_CHECK_EQUAL(text, result);
+}
+
+/* ensures that reading a 8M bytes text works well too */
+BOOST_AUTO_TEST_CASE( test_mem_scheme_in )
+{
+    Call_Guard fn([&]() {deleteAllMemStreamStrings();});
+
+    string text("");
+    {
+        string pattern("AbCdEfGh");
+        text.reserve(pattern.size() * 1000000);
+        for (int i = 0; i < 1000000; i++) {
+            text += pattern;
+        }
+        setMemStreamString("in_file.txt", text);
+    }
+
+    string result;
+    ML::filter_istream inS("mem://in_file.txt");
+    while (inS) {
+        char buf[16384];
+        inS.read(buf, 16384);
+        result.append(buf, inS.gcount());
+    }
+
+    BOOST_CHECK_EQUAL(text, result);
 }


### PR DESCRIPTION
This scheme is meant to facillitate the testing of filters without relying on remote backends, which can be a problem for testing operations on large files.
