### PR TITLE
Fix parsing of utf8 escape character

### DIFF
--- a/utils/fast_int_parsing.h
+++ b/utils/fast_int_parsing.h
@@ -73,6 +73,44 @@ inline bool match_int(long int & result, Parse_Context & c)
     return true;
 }
 
+inline bool match_hex4(long int & result, Parse_Context & c)
+{
+    Parse_Context::Revert_Token tok(c);
+
+    int code = 0;
+    unsigned digits = 0;
+    
+    for(unsigned i=0 ; i<4; ++i) {
+        int digit;
+        if(isalnum(*c)) {
+            int car = *c;
+            if (car >= '0' && car <= '9')
+                digit = car - '0';
+            else if (car >= 'a' && car <= 'f')
+                digit = car - 'a';
+            else if (car >= 'A' && car <= 'F')
+                digit = car - 'A';
+            else {
+                return false;
+            }
+            code = (code << 4) | digit;
+            ++digits;
+        }
+        else {
+            break;
+        }
+        c++;
+    }
+
+    if(digits!=4)
+        return false;
+
+    result = code;
+
+    tok.ignore();
+    return true;
+}
+
 inline bool match_unsigned_long(unsigned long & val,
                                 Parse_Context & c)
 {

--- a/utils/json_parsing.cc
+++ b/utils/json_parsing.cc
@@ -121,7 +121,7 @@ bool matchJsonString(Parse_Context & context, std::string & str)
         case '\\':result.push_back('\\');  break;
         case '"': result.push_back('"');   break;
         case 'u': {
-            int code = context.expect_int();
+            int code = context.expect_hex4();
             if (code<0 || code>255)
             {
                 return false;
@@ -165,7 +165,7 @@ std::string expectJsonStringAsciiPermissive(Parse_Context & context, char sub)
             case '\\':c = '\\';  break;
             case '"': c = '"';   break;
             case 'u': {
-                int code = context.expect_int();
+                int code = context.expect_hex4();
                 c = code;
                 break;
             }
@@ -217,7 +217,7 @@ ssize_t expectJsonStringAscii(Parse_Context & context, char * buffer, size_t max
             case '\\':c = '\\';  break;
             case '"': c = '"';   break;
             case 'u': {
-                int code = context.expect_int();
+                int code = context.expect_hex4();
                 if (code<0 || code>255) {
                     context.exception(format("non 8bit char %d", code));
                 }
@@ -277,7 +277,7 @@ std::string expectJsonStringAscii(Parse_Context & context)
             case '\\':c = '\\';  break;
             case '"': c = '"';   break;
             case 'u': {
-                int code = context.expect_int();
+                int code = context.expect_hex4();
                 if (code<0 || code>255) {
                     context.exception(format("non 8bit char %d", code));
                 }

--- a/utils/parse_context.cc
+++ b/utils/parse_context.cc
@@ -228,6 +228,28 @@ expect_int(int min, int max, const char * error)
 
 bool
 Parse_Context::
+match_hex4(int & val_, int min, int max)
+{
+    Revert_Token tok(*this);
+    long val = 0;
+    if (!ML::match_hex4(val, *this)) return false;
+    if (val < min || val > max) return false;
+    val_ = val;
+    tok.ignore();
+    return true;
+}
+
+int
+Parse_Context::
+expect_hex4(int min, int max, const char * error)
+{
+    int result;
+    if (!match_hex4(result, min, max)) exception(error);
+    return result;
+}
+
+bool
+Parse_Context::
 match_unsigned(unsigned & val_, unsigned min, unsigned max)
 {
     Revert_Token tok(*this);

--- a/utils/parse_context.h
+++ b/utils/parse_context.h
@@ -280,6 +280,12 @@ struct Parse_Context {
     int expect_int(int min = -INT_MAX, int max = INT_MAX,
                    const char * error = "expected integer");
 
+    bool match_hex4(int & val, int min = -INT_MAX, int max = INT_MAX);
+    
+    int expect_hex4(int min = -INT_MAX, int max = INT_MAX,
+                   const char * error = "invalid hexadecimal in code");
+
+
     bool match_unsigned(unsigned & val, unsigned min = 0,
                         unsigned max = INT_MAX);
     


### PR DESCRIPTION
Parsing was assuming that escape character for utf8 was an integer instead of hexadecimal value.
Update parsing of uft8 escape character for hexadecimal.

This function also verify that hexadecimal value contains 4 characters and return an error in case of.
