### PR TITLE
Added missing header to wakeup_fd (TRIVIAL)

### DIFF
--- a/arch/wakeup_fd.h
+++ b/arch/wakeup_fd.h
@@ -10,6 +10,7 @@
 #define __jml__arch__wakeup_fd_h__
 
 #include <sys/eventfd.h>
+#include <unistd.h>
 #include "exception.h"
 
 namespace ML {


### PR DESCRIPTION
Needed for gcc 4.7 compilation, where the standard library brings less headers
in.
