### PR TITLE
Fix a typo in header guard macro

### DIFF
--- a/db/nested_archive.h
+++ b/db/nested_archive.h
@@ -21,7 +21,7 @@
 */
 
 #ifndef __db__nested_archive_h__
-#define __db__nested_arhcive_h__
+#define __db__nested_archive_h__
 
 #include "persistent.h"
 #include <sstream>


### PR DESCRIPTION
Hi,

I just fixed a typo in a header guard macro.

York
